### PR TITLE
Repository name defaults to current directory

### DIFF
--- a/new-dual-repo.sh
+++ b/new-dual-repo.sh
@@ -98,7 +98,7 @@ if [[ "$REPO_NAME" == "" ]]
 then
 	if [ "$#" = "0" ]
 	then
-		read "?What should the new repo be called (slug name): " REPO_NAME
+		REPO_NAME=${PWD##*/}
 	else
 		REPO_NAME="$@"
 	fi


### PR DESCRIPTION
If a name is not explicitly supplied on the command line, the name of the current directory is used for the repository name.

[update] My reason for this change is that it is the git standard is to clone a new repository into a new directory which has the name of the repo you're cloning.

With this change, while you can explicitly name your repo something else, the standard, easiest path is now to use the directory name.